### PR TITLE
bigquery: use Pool to create a pool of clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 
 
+## [3.0.1] - 2018-08-06
+
+### Fixed
+* Scheduler: Upload grid metadata as required by Chart Studio  (#504)
+* OnPrem: Fixed /external-data-connector page not accessible in private mode
+  (#505)
+
+
 ## [3.0.0] - 2018-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 
 
+## [3.0.2] - 2018-08-10
+
+### Fixed
+* Scheduler: Handle query updates that change the names or the number of columns
+  (#511)
+* OnPrem: Fixed login link in modal window (#512)
+
+
 ## [3.0.1] - 2018-08-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 
 
+## [3.0.3] - 2018-08-13
+
+### Added
+* OnPrem: Added env variable `PLOTY_CONNECTOR_BASE_URL` to customise the
+  `connectorUrl` set in a query metadata (#514)
+
+### Fixed
+* OnPrem: Fixed connectorUrl in query metadata
+  (https://github.com/plotly/streambed/issues/11310)
+
+
 ## [3.0.2] - 2018-08-10
 
 ### Fixed

--- a/NEW_RELEASE.md
+++ b/NEW_RELEASE.md
@@ -32,3 +32,8 @@ This document lists conventions and steps to follow for creating a release.
 
 - [ ] Create branch `M.m-onprem`
 - [ ] Create Quay tag `M.m-onprem` (Visit https://quay.io/repository/plotly/falcon-sql-client?tab=tags , click the gear icon next to the thing you want to tag, then choose “Add new…")
+
+## Additional Checklist for an OnPrem Update
+
+- [ ] Create Quay tag `M.m.p-onprem` (Visit https://quay.io/repository/plotly/falcon-sql-client?tab=tags , click the gear icon next to the thing you want to tag, then choose “Add new…")
+

--- a/app/actions/sessions.js
+++ b/app/actions/sessions.js
@@ -166,7 +166,6 @@ export function createScheduledQuery(connectionId, payload = {}) {
         fid: payload.fid,
         filename: payload.filename,
         name: payload.name,
-        refreshInterval: payload.refreshInterval,
         query: payload.query,
         cronInterval: payload.cronInterval,
         connectionId
@@ -189,7 +188,6 @@ export function updateScheduledQuery(connectionId, payload = {}) {
       fid: payload.fid,
       filename: payload.filename,
       name: payload.name,
-      refreshInterval: payload.refreshInterval,
       query: payload.query,
       cronInterval: payload.cronInterval,
       connectionId

--- a/app/actions/sessions.js
+++ b/app/actions/sessions.js
@@ -203,7 +203,7 @@ export function updateScheduledQuery(connectionId, payload = {}) {
       if (!res.error) {
         dispatch({
           type: 'UPDATE_SCHEDULED_QUERY',
-          payload: body
+          payload: res
         });
       }
       return res;

--- a/app/components/Settings/Settings.react.js
+++ b/app/components/Settings/Settings.react.js
@@ -15,7 +15,7 @@ import Preview from './Preview/Preview.react';
 import {Link} from '../Link.react';
 import Scheduler from './scheduler/scheduler.jsx';
 import {DIALECTS, FAQ, PREVIEW_QUERY, SQL_DIALECTS_USING_EDITOR} from '../../constants/constants.js';
-import {isElectron, isOnPrem} from '../../utils/utils';
+import {isElectron, isOnPrem, homeUrl} from '../../utils/utils';
 
 class Settings extends Component {
     constructor(props) {
@@ -25,7 +25,7 @@ class Settings extends Component {
         this.renderSettingsForm = this.renderSettingsForm.bind(this);
         this.updateSelectedPanel = this.updateSelectedPanel.bind(this);
         this.openScheduler = this.openScheduler.bind(this);
-        this.openLogin = () => window.location.assign('/login');
+        this.openLogin = () => window.location.assign(`${homeUrl()}/login`);
         this.state = {
             editMode: true,
             selectedPanel: {},

--- a/app/components/Settings/Settings.react.js
+++ b/app/components/Settings/Settings.react.js
@@ -511,7 +511,7 @@ class Settings extends Component {
                                 <p style={{textAlign: 'right'}}>
                                     Not logged in
                                     <br/>
-                                    <a onClick={() => window.location.assign('/login')}>Log into Plotly</a>
+                                    <a onClick={() => window.location.assign(`${homeUrl()}/login`)}>Log into Plotly</a>
                                 </p>
                             )}
                         </TabPanel> }

--- a/app/components/Settings/scheduler/create-modal.jsx
+++ b/app/components/Settings/scheduler/create-modal.jsx
@@ -12,12 +12,7 @@ import TimedMessage from './timed-message.jsx';
 import CronPicker from '../cron-picker/cron-picker.jsx';
 import SQL from './sql.jsx';
 
-import {
-    getHighlightMode,
-    DEFAULT_REFRESH_INTERVAL,
-    WAITING_MESSAGE,
-    SAVE_WARNING
-} from '../../../constants/constants.js';
+import {getHighlightMode, WAITING_MESSAGE, SAVE_WARNING} from '../../../constants/constants.js';
 
 import './create-modal.css';
 
@@ -109,7 +104,6 @@ class CreateModal extends Component {
         this.props
             .onSubmit({
                 query: this.state.code,
-                refreshInterval: DEFAULT_REFRESH_INTERVAL,
                 filename: generateFilename(),
                 cronInterval: this.state.interval,
                 name: this.state.name ? this.state.name.trim() : ''

--- a/app/components/Settings/scheduler/create-modal.jsx
+++ b/app/components/Settings/scheduler/create-modal.jsx
@@ -6,12 +6,14 @@ import cronstrue from 'cronstrue';
 
 import {Row, Column} from '../../layout.jsx';
 import Modal from '../../modal.jsx';
+import {Link} from '../../Link.react';
 import SuccessMessage from '../../success.jsx';
 import RequestError from './request-error.jsx';
 import TimedMessage from './timed-message.jsx';
 import CronPicker from '../cron-picker/cron-picker.jsx';
 import SQL from './sql.jsx';
 
+import {datasetUrl as getDatasetURL} from '../../../utils/utils';
 import {getHighlightMode, WAITING_MESSAGE, SAVE_WARNING} from '../../../constants/constants.js';
 
 import './create-modal.css';
@@ -62,7 +64,8 @@ class CreateModal extends Component {
             name: props.initialName,
             interval: '*/5 * * * *',
             error: null,
-            saving: false
+            saving: false,
+            datasetUrl: null
         };
         this.options = {
             lineWrapping: true,
@@ -108,8 +111,12 @@ class CreateModal extends Component {
                 cronInterval: this.state.interval,
                 name: this.state.name ? this.state.name.trim() : ''
             })
-            .then(() => {
-                this.setState({successMessage: 'Scheduled query saved successfully!', saving: false});
+            .then((res) => {
+                this.setState({
+                  successMessage: 'Scheduled query saved successfully!',
+                  saving: false,
+                  datasetUrl: getDatasetURL(res.fid)
+                });
             })
             .catch(error => this.setState({error: error.message, saving: false}));
     }
@@ -193,7 +200,11 @@ class CreateModal extends Component {
                     </Column>
                     <Row>
                         {this.state.successMessage ? (
-                            <SuccessMessage>{this.state.successMessage}</SuccessMessage>
+                            <Column style={{ padding: '0 32px 16px' }}>
+                              <SuccessMessage message={this.state.successMessage}>
+                                <Link href={this.state.datasetUrl}>View Live Dataset</Link>
+                              </SuccessMessage>
+                            </Column>
                         ) : (
                             <Column>
                                 <button type="submit" className="submit" onClick={this.submit}>

--- a/app/components/Settings/scheduler/preview-modal.jsx
+++ b/app/components/Settings/scheduler/preview-modal.jsx
@@ -13,12 +13,7 @@ import CronPicker from '../cron-picker/cron-picker.jsx';
 import {Row, Column} from '../../layout.jsx';
 import SQL from './sql.jsx';
 import {plotlyUrl} from '../../../utils/utils.js';
-import {
-    getHighlightMode,
-    DEFAULT_REFRESH_INTERVAL,
-    WAITING_MESSAGE,
-    SAVE_WARNING
-} from '../../../constants/constants.js';
+import {getHighlightMode, WAITING_MESSAGE, SAVE_WARNING} from '../../../constants/constants.js';
 import {getInitialCronMode} from '../cron-picker/cron-helpers.js';
 
 const NO_OP = () => {};
@@ -85,7 +80,7 @@ export class PreviewModal extends Component {
 
     onSubmit() {
         if (this.state.editing) {
-            const {connectionId, fid, requestor, uids, refreshInterval} = this.props.query;
+            const {connectionId, fid, requestor, uids} = this.props.query;
             const {code: query, cronInterval} = this.state;
             const name = this.state.name ? this.state.name.trim() : '';
 
@@ -98,8 +93,7 @@ export class PreviewModal extends Component {
                     uids,
                     query,
                     name,
-                    cronInterval,
-                    refreshInterval: refreshInterval || DEFAULT_REFRESH_INTERVAL
+                    cronInterval
                 })
                 .then(() => {
                     this.setState({

--- a/app/components/Settings/scheduler/preview-modal.jsx
+++ b/app/components/Settings/scheduler/preview-modal.jsx
@@ -12,7 +12,7 @@ import {Link} from '../../Link.react.js';
 import CronPicker from '../cron-picker/cron-picker.jsx';
 import {Row, Column} from '../../layout.jsx';
 import SQL from './sql.jsx';
-import {plotlyUrl} from '../../../utils/utils.js';
+import {datasetUrl} from '../../../utils/utils.js';
 import {getHighlightMode, WAITING_MESSAGE, SAVE_WARNING} from '../../../constants/constants.js';
 import {getInitialCronMode} from '../cron-picker/cron-helpers.js';
 
@@ -156,7 +156,11 @@ export class PreviewModal extends Component {
         }
 
         if (success) {
-            return <SuccessMessage>{this.state.successMessage}</SuccessMessage>;
+            return (
+              <Column>
+                <SuccessMessage>{this.state.successMessage}</SuccessMessage>
+              </Column>
+            );
         }
 
         if (editing) {
@@ -196,8 +200,7 @@ export class PreviewModal extends Component {
         if (!props.query) {
             content = null;
         } else {
-            const [account, gridId] = props.query.fid.split(':');
-            const link = `${plotlyUrl()}/~${account}/${gridId}`;
+            const link = datasetUrl(props.query.fid);
             const {editing, loading} = this.state;
 
             const initialModeId = getInitialCronMode(props.query);

--- a/app/components/Settings/scheduler/preview-modal.jsx
+++ b/app/components/Settings/scheduler/preview-modal.jsx
@@ -308,7 +308,7 @@ export class PreviewModal extends Component {
                                 </div>
                             ) : (
                                 <em style={valueStyle}>
-                                    {props.query.cronInterval ? (
+                                    {this.state.cronInterval ? (
                                         <b>{cronstrue.toString(this.state.cronInterval)}</b>
                                     ) : (
                                         <React.Fragment>

--- a/app/components/Settings/scheduler/request-error.jsx
+++ b/app/components/Settings/scheduler/request-error.jsx
@@ -50,6 +50,17 @@ function FormattedMessage(props) {
         );
     }
 
+    if (content.startsWith('MetadataError')) {
+        return (
+            <details style={outlineStyle}>
+                <summary style={outlineStyle}>
+                    An unexpected error occurred while uploading query metadata. Please try again now.
+                </summary>
+                <pre>{capitalize(content.replace('MetadataError: ', ''))}</pre>
+            </details>
+        );
+    }
+
     return content.slice(0, 100);
 }
 

--- a/app/components/success.jsx
+++ b/app/components/success.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const style = {marginBottom: 16, fontSize: 16, color: '#00cc96'};
+const style = {fontSize: 16};
 const SuccessMessage = (props) => (
-  <em style={style}>
+  <div style={{ padding: '8px 16px', borderLeft: '4px solid #00cc96', background: 'white'}}>
+    <div style={style}>{props.message}</div>
     {props.children}
-  </em>
+  </div>
 );
 
 SuccessMessage.propTypes = {
-  children: PropTypes.node
+  children: PropTypes.node,
+  message: PropTypes.string
 };
 
 export default SuccessMessage;

--- a/app/constants/constants.js
+++ b/app/constants/constants.js
@@ -2,12 +2,6 @@
 /* eslint-disable no-multi-str */
 import {concat} from 'ramda';
 
-/**
- * Default to '1 week' for `refreshInterval` for backwards compatability. For
- * older versions this will prevent issues such as `setInterval(runQuery, NaN)`
- */
-export const DEFAULT_REFRESH_INTERVAL = 7 * 24 * 60 * 60;
-
 export const DIALECTS = {
     MYSQL: 'mysql',
     MARIADB: 'mariadb',

--- a/app/constants/constants.js
+++ b/app/constants/constants.js
@@ -266,7 +266,7 @@ export const CONNECTION_CONFIG = {
         {'label': 'Database', 'value': 'database', 'type': 'text'},
         {
             'label': 'Key File',
-            'value': 'keyfileName',
+            'value': 'keyFilename',
             'type': 'filedrop',
             'description': `The location of the Google Service Account Key File`
         }
@@ -511,7 +511,7 @@ export const SAMPLE_DBS = {
     [DIALECTS.BIGQUERY]: {
         projectId: 'Plotly',
         database: 'plotly',
-        keyfileName: '/home/plotly/falcon/google-credentials.json'
+        keyFilename: '/home/plotly/falcon/google-credentials.json'
     }
 };
 

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -59,6 +59,11 @@ export function homeUrl() {
         '';
 }
 
+export function datasetUrl(fid) {
+  const [account, gridId] = fid.split(':');
+  return `${plotlyUrl()}/~${account}/${gridId}`;
+}
+
 export function getPathNames(url) {
     const parser = document.createElement('a');
     parser.href = url;

--- a/backend/persistent/QueryScheduler.js
+++ b/backend/persistent/QueryScheduler.js
@@ -221,7 +221,7 @@ class QueryScheduler {
                     metadata: {
                         query,
                         connectionId,
-                        connectorUrl: `https://${getSetting('CONNECTOR_HTTPS_DOMAIN')}:${getSetting('PORT_HTTPS')}`
+                        connectorUrl: getSetting('BASE_URL')
                     },
                     refresh_interval: formattedRefresh
                 }
@@ -377,7 +377,7 @@ class QueryScheduler {
                     metadata: {
                         query,
                         connectionId,
-                        connectorUrl: `https://${getSetting('CONNECTOR_HTTPS_DOMAIN')}:${getSetting('PORT_HTTPS')}`
+                        connectorUrl: getSetting('BASE_URL')
                     },
                     refresh_interval: formattedRefresh
                 }

--- a/backend/persistent/QueryScheduler.js
+++ b/backend/persistent/QueryScheduler.js
@@ -391,7 +391,8 @@ class QueryScheduler {
             Logger.log(`Request to Plotly for creating a grid took ${process.hrtime(startTime)[0]} seconds`, 2);
             Logger.log(`Grid ${fid} has been updated.`, 2);
 
-            if (res.status !== 200) {
+            // res is undefined if the `deleteQuery` is returned above
+            if (res && res.status && res.status !== 200) {
               throw new Error(`MetadataError: error updating grid metadata (status: ${res.status})`);
             }
 

--- a/backend/persistent/QueryScheduler.js
+++ b/backend/persistent/QueryScheduler.js
@@ -37,7 +37,7 @@ class QueryScheduler {
 
         // this.job wraps this.queryAndUpdateGrid to avoid concurrent runs of the same job
         this.runningJobs = {};
-        this.job = (fid, uids, query, connectionId, requestor) => {
+        this.job = (fid, query, connectionId, requestor) => {
             try {
                 if (this.runningJobs[fid]) {
                     return;
@@ -45,7 +45,7 @@ class QueryScheduler {
 
                 this.runningJobs[fid] = true;
 
-                return this.queryAndUpdateGrid(fid, uids, query, connectionId, requestor)
+                return this.queryAndUpdateGrid(fid, query, connectionId, requestor)
                     .catch(error => {
                         Logger.log(error, 0);
                     }).then(() => {
@@ -239,7 +239,7 @@ class QueryScheduler {
         });
     }
 
-    queryAndUpdateGrid(fid, uids, query, connectionId, requestor, cronInterval, refreshInterval) {
+    queryAndUpdateGrid(fid, query, connectionId, requestor, cronInterval, refreshInterval) {
         const requestedDBConnections = getConnectionById(connectionId);
         const formattedRefresh = refreshInterval || mapCronToRefresh(cronInterval);
         let startTime = process.hrtime();
@@ -298,7 +298,6 @@ class QueryScheduler {
                 rows,
                 columnnames,
                 fid,
-                uids,
                 requestor
             ).catch((e) => {
                 /*

--- a/backend/persistent/QueryScheduler.js
+++ b/backend/persistent/QueryScheduler.js
@@ -387,19 +387,25 @@ class QueryScheduler {
                 */
                 throw new Error(`MetadataError: ${e.message}`);
             });
-        }).then(() => {
+        }).then(res => {
             Logger.log(`Request to Plotly for creating a grid took ${process.hrtime(startTime)[0]} seconds`, 2);
             Logger.log(`Grid ${fid} has been updated.`, 2);
+
+            if (res.status !== 200) {
+              throw new Error(`MetadataError: error updating grid metadata (status: ${res.status})`);
+            }
 
             startTime = process.hrtime();
 
             // fetch updated grid column for returning
             return getGridColumn(fid, requestor);
-        }).then((res) => {
+        }).then(res => {
             Logger.log(`Request to Plotly for fetching updated grid took ${process.hrtime(startTime)[0]} seconds`, 2);
+
             if (res.status !== 200) {
-              return res.text();
+              throw new Error(`PlotlyApiError: error fetching updated columns (status: ${res.status})`);
             }
+
             return res.json();
         });
     }

--- a/backend/persistent/QueryScheduler.js
+++ b/backend/persistent/QueryScheduler.js
@@ -21,7 +21,7 @@ import {
     newGrid,
     patchGrid,
     updateGrid,
-    getGrid
+    getGridColumn
 } from './plotly-api.js';
 
 const SUCCESS_CODES = [200, 201, 204];
@@ -393,8 +393,8 @@ class QueryScheduler {
 
             startTime = process.hrtime();
 
-            // fetch updated grid for returning
-            return getGrid(fid, requestor);
+            // fetch updated grid column for returning
+            return getGridColumn(fid, requestor);
         }).then((res) => {
             Logger.log(`Request to Plotly for fetching updated grid took ${process.hrtime(startTime)[0]} seconds`, 2);
             if (res.status !== 200) {

--- a/backend/persistent/QueryScheduler.js
+++ b/backend/persistent/QueryScheduler.js
@@ -37,15 +37,14 @@ class QueryScheduler {
 
         // this.job wraps this.queryAndUpdateGrid to avoid concurrent runs of the same job
         this.runningJobs = {};
-        this.job = (fid, query, connectionId, requestor) => {
+        this.job = (fid, query, connectionId, requestor, cronInterval, refreshInterval) => {
             try {
                 if (this.runningJobs[fid]) {
                     return;
                 }
 
                 this.runningJobs[fid] = true;
-
-                return this.queryAndUpdateGrid(fid, query, connectionId, requestor)
+                return this.queryAndUpdateGrid(fid, query, connectionId, requestor, cronInterval, refreshInterval)
                     .catch(error => {
                         Logger.log(error, 0);
                     }).then(() => {
@@ -116,7 +115,7 @@ class QueryScheduler {
         saveQuery(queryParams);
 
         // Schedule
-        const job = () => this.job(fid, uids, query, connectionId, requestor);
+        const job = () => this.job(fid, query, connectionId, requestor, cronInterval, refreshInterval);
         let jobInterval = cronInterval;
         if (!jobInterval) {
             // convert refresh interval to cron representation

--- a/backend/persistent/QueryScheduler.js
+++ b/backend/persistent/QueryScheduler.js
@@ -397,6 +397,9 @@ class QueryScheduler {
             return getGrid(fid, requestor);
         }).then((res) => {
             Logger.log(`Request to Plotly for fetching updated grid took ${process.hrtime(startTime)[0]} seconds`, 2);
+            if (res.status !== 200) {
+              return res.text();
+            }
             return res.json();
         });
     }

--- a/backend/persistent/datastores/athena.js
+++ b/backend/persistent/datastores/athena.js
@@ -65,11 +65,7 @@ export function query(queryObject, connection) {
  */
 export function schemas(connection) {
     const sqlStatement = `${SHOW_SCHEMA_QUERY} = '${connection.database}'` ;
-    let rst= query(sqlStatement, connection);
-
-    return rst.then( r=>{
-        console.log( 'R',r);
-    });
+    return query(sqlStatement, connection);
 }
 
 

--- a/backend/persistent/plotly-api.js
+++ b/backend/persistent/plotly-api.js
@@ -6,6 +6,7 @@ import {
     getCredentials,
     getSetting
 } from '../settings.js';
+import {extractOrderedUids} from '../utils/gridUtils.js';
 
 
 // Module to access Plot.ly REST API
@@ -164,7 +165,7 @@ export function patchGrid(fid, requestor, body) {
     });
 }
 
-export function updateGrid(rows, columnnames, fid, _unusedUIDs, requestor) {
+export function updateGrid(rows, columnnames, fid, requestor) {
     const numColumns = columnnames.length;
     const columns = getColumns(rows, numColumns);
     const columnEntries = columns.map((column, columnIndex) => {
@@ -188,10 +189,7 @@ export function updateGrid(rows, columnnames, fid, _unusedUIDs, requestor) {
               return data;
           }
 
-          const uids = Object.keys(data.cols)
-            .map(key => data.cols[key])
-            .sort((a, b) => a.order - b.order)
-            .map(col => col.uid);
+          const uids = extractOrderedUids(data);
 
           if (numColumns > uids.length) {
               // repopulate existing columns

--- a/backend/persistent/plotly-api.js
+++ b/backend/persistent/plotly-api.js
@@ -165,6 +165,17 @@ export function patchGrid(fid, requestor, body) {
     });
 }
 
+export function getGridColumn(fid, requestor) {
+    const {username, apiKey, accessToken} = getCredentials(requestor);
+
+    return plotlyAPIRequest(`grids/${fid}/col`, {
+        method: 'GET',
+        username,
+        apiKey,
+        accessToken
+    });
+}
+
 export function updateGrid(rows, columnnames, fid, requestor) {
     const numColumns = columnnames.length;
     const columns = getColumns(rows, numColumns);
@@ -177,7 +188,7 @@ export function updateGrid(rows, columnnames, fid, requestor) {
     const baseParams = { username, apiKey, accessToken };
 
     // fetch latest grid to get the source of truth
-    return plotlyAPIRequest(baseUrl, { ...baseParams, method: 'GET' })
+    return getGridColumn(fid, requestor)
         .then(res => {
             if (res.status !== 200) {
                 return res;

--- a/backend/persistent/plotly-api.js
+++ b/backend/persistent/plotly-api.js
@@ -178,76 +178,78 @@ export function updateGrid(rows, columnnames, fid, requestor) {
 
     // fetch latest grid to get the source of truth
     return getGrid(fid, requestor)
-      .then(res => {
-          if (res.status !== 200) {
-              return res;
-          }
-          return res.json();
-      }).then(data => {
-          if (data.status) {
-              // bad res was passed along, return it
-              return data;
-          }
+        .then(res => {
+            if (res.status !== 200) {
+                return res;
+            }
+            return res.json();
+        }).then(data => {
+            if (data.status) {
+                // bad res was passed along, return it
+                return data;
+            }
 
-          const uids = extractOrderedUids(data);
+            const uids = extractOrderedUids(data);
 
-          if (numColumns > uids.length) {
-              // repopulate existing columns
-              const putUrl = `${baseUrl}?uid=${uids.join(',')}`;
-              const putBody = { cols: columnEntries.slice(0, uids.length) };
+            if (numColumns > uids.length) {
+                // repopulate existing columns
+                const putUrl = `${baseUrl}?uid=${uids.join(',')}`;
+                const putBody = { cols: columnEntries.slice(0, uids.length) };
 
-              // append new columns
-              const postUrl = baseUrl;
-              const postBody = { cols: columnEntries.slice(uids.length) };
+                // append new columns
+                const postUrl = baseUrl;
+                const postBody = { cols: columnEntries.slice(uids.length) };
 
-              return plotlyAPIRequest(postUrl, {
-                  ...baseParams,
-                  body: postBody,
-                  method: 'POST'
-              }).then((res) => {
-                  if (res.status !== 200) {
-                      return res;
-                  }
+                return plotlyAPIRequest(postUrl, {
+                    ...baseParams,
+                    body: postBody,
+                    method: 'POST'
+                }).then((res) => {
+                    if (res.status !== 200) {
+                        return res;
+                    }
 
-                  return plotlyAPIRequest(putUrl, {
-                      ...baseParams,
-                      body: putBody,
-                      method: 'PUT'
-                  });
-              });
-          } else if (numColumns < uids.length) {
-              // repopulate existing columns
-              const putUrl = `${baseUrl}?uid=${uids.slice(0, numColumns).join(',')}`;
-              const putBody = { cols: columnEntries };
+                    return plotlyAPIRequest(putUrl, {
+                        ...baseParams,
+                        body: putBody,
+                        method: 'PUT'
+                    });
+                });
+            } else if (numColumns < uids.length) {
+                // delete unused existing columns
+                const deleteUrl = `${baseUrl}?uid=${uids.slice(numColumns)}`;
 
-              // delete unused existing columns
-              const deleteUrl = `${baseUrl}?uid=${uids.slice(numColumns)}`;
+                // repopulate used existing columns
+                const putUrl = `${baseUrl}?uid=${uids.slice(0, numColumns).join(',')}`;
+                const putBody = { cols: columnEntries };
 
-              return plotlyAPIRequest(putUrl, {
-                  ...baseParams,
-                  body: putBody,
-                  method: 'PUT'
-              }).then((res) => {
-                  if (res.status !== 200) {
-                      return res;
-                  }
 
-                  return plotlyAPIRequest(deleteUrl, {
-                      ...baseParams,
-                      method: 'DELETE'
-                  });
-              });
-          }
 
-          // repopulate existing columns
-          const putUrl = `${baseUrl}?uid=${uids.join(',')}`;
-          const putBody = { cols: columnEntries };
+                return plotlyAPIRequest(deleteUrl, {
+                    ...baseParams,
+                    method: 'DELETE'
+                }).then((res) => {
+                    if (res.status !== 204) {
+                        return res;
+                    }
 
-          return plotlyAPIRequest(putUrl, {
-              ...baseParams,
-              body: putBody,
-              method: 'PUT'
-          });
+                    return plotlyAPIRequest(putUrl, {
+                        ...baseParams,
+                        body: putBody,
+                        method: 'PUT'
+                    });
+                });
+            }
+
+            // repopulate existing columns
+            const putUrl = `${baseUrl}?uid=${uids.join(',')}`;
+            const putBody = { cols: columnEntries };
+
+            return plotlyAPIRequest(putUrl, {
+                ...baseParams,
+                body: putBody,
+                method: 'PUT'
+            });
     });
 }
 

--- a/backend/persistent/plotly-api.js
+++ b/backend/persistent/plotly-api.js
@@ -175,10 +175,19 @@ export function updateGrid(rows, columnnames, fid, _unusedUIDs, requestor) {
     const baseUrl = `grids/${fid}/col`;
     const baseParams = { username, apiKey, accessToken };
 
-    // Fetch latest Grid to get the source of truth
+    // fetch latest grid to get the source of truth
     return getGrid(fid, requestor)
-      .then(res => res.json())
-      .then(data => {
+      .then(res => {
+          if (res.status !== 200) {
+              return res;
+          }
+          return res.json();
+      }).then(data => {
+          if (data.status) {
+              // bad res was passed along, return it
+              return data;
+          }
+
           const uids = Object.keys(data.cols)
             .map(key => data.cols[key])
             .sort((a, b) => a.order - b.order)

--- a/backend/persistent/plotly-api.js
+++ b/backend/persistent/plotly-api.js
@@ -152,6 +152,18 @@ export function deleteGrid(fid, requestor) {
     });
 }
 
+export function patchGrid(fid, requestor, body) {
+    const {username, apiKey, accessToken} = getCredentials(requestor);
+
+    return plotlyAPIRequest(`grids/${fid}`, {
+        method: 'PATCH',
+        username,
+        apiKey,
+        accessToken,
+        body
+    });
+}
+
 export function updateGrid(rows, fid, uids, requestor) {
     const {username, apiKey, accessToken} = getCredentials(requestor);
 

--- a/backend/persistent/plotly-api.js
+++ b/backend/persistent/plotly-api.js
@@ -177,7 +177,7 @@ export function updateGrid(rows, columnnames, fid, requestor) {
     const baseParams = { username, apiKey, accessToken };
 
     // fetch latest grid to get the source of truth
-    return getGrid(fid, requestor)
+    return plotlyAPIRequest(baseUrl, { ...baseParams, method: 'GET' })
         .then(res => {
             if (res.status !== 200) {
                 return res;

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -8,6 +8,7 @@ import path from 'path';
 
 import {PlotlyOAuth} from './plugins/authorization.js';
 import {generateAndSaveAccessToken} from './utils/authUtils.js';
+import {extractOrderedUids} from './utils/gridUtils.js';
 import {
     getAccessTokenCookieOptions,
     getCookieOptions,
@@ -667,7 +668,6 @@ export default class Servers {
             const {
                 filename,
                 fid,
-                uids,
                 query,
                 connectionId,
                 requestor,
@@ -700,29 +700,34 @@ export default class Servers {
             if (fid) {
                 return checkWritePermissions(fid, requestor).then(function () {
                     return that.queryScheduler.queryAndUpdateGrid(
-                        fid, uids, query, connectionId, requestor, cronInterval, refreshInterval
+                        fid, query, connectionId, requestor, cronInterval, refreshInterval
                     );
                 })
                 .then((updatedGridResponse) => {
-                    const orderedUids =
-                        Object.keys(updatedGridResponse.cols)
-                        .map(key => updatedGridResponse.cols[key])
-                        .sort((a, b) => a.order - b.order)
-                        .map(col => col.uid);
-
-                    const queryObject = {
-                        ...req.params,
-                        uids: orderedUids
-                    };
+                    const orderedUids = extractOrderedUids(updatedGridResponse);
+                    const previousQuery = getQuery(req.params.fid);
 
                     let status;
-                    if (getQuery(req.params.fid)) {
+                    if (previousQuery) {
                         // TODO - Technically, this should be
                         // under the endpoint `/queries/:fid`
                         status = 200;
                     } else {
                         status = 201;
                     }
+
+                    let oldParamsToCarryOver = {};
+                    if (previousQuery) {
+                        const {name} = previousQuery;
+                        oldParamsToCarryOver = {name};
+                    }
+
+                    const queryObject = {
+                        ...oldParamsToCarryOver,
+                        ...req.params,
+                        uids: orderedUids
+                    };
+
                     that.queryScheduler.scheduleQuery(queryObject);
                     res.json(status, queryObject);
                     return next();

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -703,7 +703,18 @@ export default class Servers {
                         fid, uids, query, connectionId, requestor, cronInterval, refreshInterval
                     );
                 })
-                .then(() => {
+                .then((updatedGridResponse) => {
+                    const orderedUids =
+                        Object.keys(updatedGridResponse.cols)
+                        .map(key => updatedGridResponse.cols[key])
+                        .sort((a, b) => a.order - b.order)
+                        .map(col => col.uid);
+
+                    const queryObject = {
+                        ...req.params,
+                        uids: orderedUids
+                    };
+
                     let status;
                     if (getQuery(req.params.fid)) {
                         // TODO - Technically, this should be
@@ -712,8 +723,8 @@ export default class Servers {
                     } else {
                         status = 201;
                     }
-                    that.queryScheduler.scheduleQuery(req.params);
-                    res.json(status, {});
+                    that.queryScheduler.scheduleQuery(queryObject);
+                    res.json(status, queryObject);
                     return next();
                 })
                 .catch(onError);

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -664,13 +664,22 @@ export default class Servers {
          * the endpoint `/queries/:fid`
          */
         server.post('/queries', function postQueriesHandler(req, res, next) {
-            const {filename, fid, uids, query, connectionId, requestor} = req.params;
+            const {
+                filename,
+                fid,
+                uids,
+                query,
+                connectionId,
+                requestor,
+                cronInterval = null,
+                refreshInterval = null
+            } = req.params;
 
             // If a filename has been provided,
             // make the query and create a new grid
             if (filename) {
                 return that.queryScheduler.queryAndCreateGrid(
-                    filename, query, connectionId, requestor
+                    filename, query, connectionId, requestor, cronInterval, refreshInterval
                 )
                 .then((newGridResponse) => {
                     const queryObject = {
@@ -691,7 +700,7 @@ export default class Servers {
             if (fid) {
                 return checkWritePermissions(fid, requestor).then(function () {
                     return that.queryScheduler.queryAndUpdateGrid(
-                        fid, uids, query, connectionId, requestor
+                        fid, uids, query, connectionId, requestor, cronInterval, refreshInterval
                     );
                 })
                 .then(() => {

--- a/backend/settings.js
+++ b/backend/settings.js
@@ -71,6 +71,7 @@ const DEFAULT_SETTINGS = {
 
 // Settings that depend on other settings are described here
 const derivedSettingsNames = [
+    'BASE_URL',
     'PLOTLY_API_URL',
     'PLOTLY_URL',
     'CONNECTIONS_PATH',
@@ -84,6 +85,11 @@ const derivedSettingsNames = [
 
 function getDerivedSetting(settingName) {
     switch (settingName) {
+        case 'BASE_URL':
+            return getSetting('IS_RUNNING_INSIDE_ON_PREM') ?
+                process.env.PLOTLY_CONNECTOR_BASE_URL :
+                `https://${getSetting('CONNECTOR_HTTPS_DOMAIN')}:${getSetting('PORT_HTTPS')}`;
+
         case 'PLOTLY_URL': {
             if (getSetting('PLOTLY_API_DOMAIN') ===
                 DEFAULT_SETTINGS.PLOTLY_API_DOMAIN) {

--- a/backend/utils/cronUtils.js
+++ b/backend/utils/cronUtils.js
@@ -22,6 +22,26 @@ export function mapRefreshToCron (refreshInterval) {
     return `${now.getMinutes()} ${now.getHours()} * * ${now.getDay()}`;
 }
 
+export function mapCronToRefresh (cronInterval) {
+    const DEFAULT_INTERVAL = 60 * 60 * 24 * 7; // default to weekly
+
+    if (!cronInterval) {
+        return DEFAULT_INTERVAL;
+    }
+
+    if (cronInterval === '* * * * *') {
+        return 60;
+    } else if (cronInterval === '*/5 * * * *') {
+        return 60 * 5;
+    } else if (cronInterval.match(/\S+? \* \* \* \*/)) {
+        return 60 * 60;
+    } else if (cronInterval.match(/\S+? \S+? \* \* \*/)) {
+        return 60 * 60 * 24;
+    }
+
+    return DEFAULT_INTERVAL;
+}
+
 function computeMinutes (now) {
     let currMinute = now.getMinutes() % 5; // start at 5 min offset
     const minutes = [];

--- a/backend/utils/gridUtils.js
+++ b/backend/utils/gridUtils.js
@@ -1,0 +1,10 @@
+export function extractOrderedUids (grid) {
+  try {
+    return Object.keys(grid.cols)
+      .map(key => grid.cols[key])
+      .sort((a, b) => a.order - b.order)
+      .map(col => col.uid);
+  } catch (e) {
+    return null;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falcon-sql-client",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Free, open-source SQL client for Windows, Mac and Linux",
   "main": "./backend/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falcon-sql-client",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Free, open-source SQL client for Windows, Mac and Linux",
   "main": "./backend/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falcon-sql-client",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Free, open-source SQL client for Windows, Mac and Linux",
   "main": "./backend/main.js",
   "scripts": {

--- a/test/app/components/Settings/scheduler/create-modal.test.jsx
+++ b/test/app/components/Settings/scheduler/create-modal.test.jsx
@@ -18,7 +18,6 @@ global.document.createRange = function() {
 
 const wait = () => new Promise(resolve => setTimeout(resolve, 0));
 
-const {DEFAULT_REFRESH_INTERVAL} = require('../../../../../app/constants/constants');
 const CodeMirror = require('react-codemirror2').Controlled;
 const CreateModal = require('../../../../../app/components/Settings/scheduler/create-modal.jsx');
 const ErrorComponent = require('../../../../../app/components/error.jsx');
@@ -93,7 +92,6 @@ describe('Create Modal Test', () => {
                 // Once filename input is supported, this value should be: 'filename',
                 filename: expect.any(String),
                 query: 'SELECT * FROM foods',
-                refreshInterval: DEFAULT_REFRESH_INTERVAL,
                 cronInterval
             })
         );
@@ -101,7 +99,6 @@ describe('Create Modal Test', () => {
             // Once filename input is supported, this value should be: 'filename',
             filename: expect.any(String),
             query: 'SELECT * FROM foods',
-            refreshInterval: DEFAULT_REFRESH_INTERVAL,
             cronInterval,
             name
         });

--- a/test/app/components/Settings/scheduler/preview-modal.jsx
+++ b/test/app/components/Settings/scheduler/preview-modal.jsx
@@ -17,7 +17,6 @@ global.document.createRange = function() {
 };
 
 const PreviewModal = require('../../../../../app/components/Settings/scheduler/preview-modal.jsx').default;
-const {DEFAULT_REFRESH_INTERVAL} = require('../../../../../app/constants/constants');
 
 describe('Preview Modal Tests', () => {
     beforeAll(() => {
@@ -155,9 +154,7 @@ describe('Preview Modal Tests', () => {
                 fid: 'fid:1',
                 requestor: 'user',
                 query: 'SELECT * FROM table',
-                cronInterval: '* * * * *',
-                // This is necessary to prevent older versions from breaking
-                refreshInterval: DEFAULT_REFRESH_INTERVAL
+                cronInterval: '* * * * *'
             })
         );
     });

--- a/test/app/components/Settings/scheduler/preview-modal.test.jsx
+++ b/test/app/components/Settings/scheduler/preview-modal.test.jsx
@@ -64,7 +64,7 @@ describe('Preview Modal Tests', () => {
                 .find('button')
                 .at(1)
                 .text()
-        ).toEqual(expect.stringContaining('Log in'));
+        ).toEqual(expect.stringContaining('Switch users'));
     });
 
     it('should render edit and delete buttons if logged in', () => {

--- a/test/backend/QueryScheduler.spec.js
+++ b/test/backend/QueryScheduler.spec.js
@@ -622,8 +622,7 @@ describe('QueryScheduler', function() {
         }
 
         function resetAndVerifyGridContents(fid, uids) {
-            const placeholderColNames = Array(uids.length).fill('_');
-            return updateGrid([[1, 2, 3, 4, 5, 6]], placeholderColNames, fid, uids, username, apiKey)
+            return updateGrid([[1, 2, 3, 4, 5, 6]], names, fid, uids, username, apiKey)
             .then(assertResponseStatus(200)).then(() => {
                 return getGrid(fid, username);
             })

--- a/test/backend/QueryScheduler.spec.js
+++ b/test/backend/QueryScheduler.spec.js
@@ -622,7 +622,8 @@ describe('QueryScheduler', function() {
         }
 
         function resetAndVerifyGridContents(fid, uids) {
-            return updateGrid([[1, 2, 3, 4, 5, 6]], fid, uids, username, apiKey)
+            const placeholderColNames = Array(uids.length).fill('_');
+            return updateGrid([[1, 2, 3, 4, 5, 6]], placeholderColNames, fid, uids, username, apiKey)
             .then(assertResponseStatus(200)).then(() => {
                 return getGrid(fid, username);
             })

--- a/test/backend/QueryScheduler.spec.js
+++ b/test/backend/QueryScheduler.spec.js
@@ -624,8 +624,8 @@ describe('QueryScheduler', function() {
             });
         }
 
-        function resetAndVerifyGridContents(fid, uids) {
-            return updateGrid([[1, 2, 3, 4, 5, 6]], names, fid, uids, username, apiKey)
+        function resetAndVerifyGridContents(fid) {
+            return updateGrid([[1, 2, 3, 4, 5, 6]], names, fid, username, apiKey)
             .then(assertResponseStatus(200)).then(() => {
                 return getGrid(fid, username);
             })
@@ -673,7 +673,7 @@ describe('QueryScheduler', function() {
         })
         .then(() => wait(1.5 * refreshInterval * 1000))
         .then(() => checkGridAgainstQuery(fid, 'First check'))
-        .then(() => resetAndVerifyGridContents(fid, uids))
+        .then(() => resetAndVerifyGridContents(fid))
         .then(() => wait(1.5 * refreshInterval * 1000))
         .then(() => checkGridAgainstQuery(fid, 'Second check'))
         .then(() => deleteGrid(fid, username));

--- a/test/backend/QueryScheduler.spec.js
+++ b/test/backend/QueryScheduler.spec.js
@@ -1,7 +1,7 @@
 import {assert} from 'chai';
 import sinon from 'sinon';
 
-import {merge} from 'ramda';
+import {merge, omit} from 'ramda';
 
 import {saveConnection} from '../../backend/persistent/Connections.js';
 import {
@@ -528,7 +528,7 @@ describe('QueryScheduler', function() {
 
     it('clears and deletes the query if its associated grid was deleted', function() {
         const refreshInterval = 5;
-        const cronInterval = `*/${refreshInterval} * * * * *`;
+        const cronInterval = `*/${refreshInterval} * * * * *`; // every 5 seconds
 
         /*
          * Save the sqlConnections to a file.
@@ -550,7 +550,6 @@ describe('QueryScheduler', function() {
             queryObject = {
                 fid,
                 uids,
-                refreshInterval,
                 cronInterval,
                 connectionId,
                 query: 'SELECT * from ebola_2014 LIMIT 2',
@@ -562,7 +561,11 @@ describe('QueryScheduler', function() {
 
             queryScheduler.scheduleQuery(queryObject);
 
-            assert.deepEqual(getQueries(), [queryObject], 'Query has not been saved');
+            assert.deepEqual(
+                getQueries().map(query => omit('refreshInterval', query)),
+                [queryObject],
+                'Query has not been saved'
+            );
             assert(Boolean(queryScheduler.queryJobs[fid]), 'Query has not been scheduled');
 
             return deleteGrid(fid, username);

--- a/test/backend/QueryScheduler.spec.js
+++ b/test/backend/QueryScheduler.spec.js
@@ -1,7 +1,7 @@
 import {assert} from 'chai';
 import sinon from 'sinon';
 
-import {merge, omit} from 'ramda';
+import {merge} from 'ramda';
 
 import {saveConnection} from '../../backend/persistent/Connections.js';
 import {
@@ -550,6 +550,7 @@ describe('QueryScheduler', function() {
             queryObject = {
                 fid,
                 uids,
+                refreshInterval,
                 cronInterval,
                 connectionId,
                 query: 'SELECT * from ebola_2014 LIMIT 2',
@@ -562,7 +563,7 @@ describe('QueryScheduler', function() {
             queryScheduler.scheduleQuery(queryObject);
 
             assert.deepEqual(
-                getQueries().map(query => omit('refreshInterval', query)),
+                getQueries(),
                 [queryObject],
                 'Query has not been saved'
             );

--- a/test/backend/QueryScheduler.spec.js
+++ b/test/backend/QueryScheduler.spec.js
@@ -464,13 +464,13 @@ describe('QueryScheduler', function() {
         clock.tick(3.25 * refreshInterval * 1000);
         assert(spy1.calledThrice, 'job1 should have been called three times');
         assert(spy1.alwaysCalledWith(
-            query.fid, query.uids, query.query,
+            query.fid, query.query,
             query.connectionId, query.requestor
         ), `job1 was called with unexpected args: ${spy1.args}`);
         assert(spy2.calledThrice, 'job2 should have been called three times');
         assert(spy2.alwaysCalledWith(
-            query.fid, query.uids, 'query-2',
-            query.connectionId, query.requestor
+            query.fid, 'query-2',
+            query.connectionId, query.requestor,
         ), `job2 was called with unexpected args: ${spy2.args}`);
 
         clock.restore();

--- a/test/backend/plotly-api.spec.js
+++ b/test/backend/plotly-api.spec.js
@@ -13,7 +13,14 @@ import {
     initGrid,
     username
 } from './utils.js';
+import {extractOrderedUids} from '../../backend/utils/gridUtils.js';
 
+function genPlaceholderColumnNames (numColumns) {
+    return Array(numColumns).fill('_').map((_, index) => `placeholder-${index}`);
+}
+
+// Note: in the following tests grids are created to begin with, but
+// the actual backend never does this — it assumes a grid already exists.
 describe('Grid API Functions', function () {
     before(() => {
         saveSetting('USERS', [{username, apiKey}]);
@@ -21,14 +28,112 @@ describe('Grid API Functions', function () {
         saveSetting('PLOTLY_API_SSL_ENABLED', true);
     });
 
-    it('updateGrid overwrites a grid with new data', function () {
-        // First, create a new grid.
-        // Note that the app never actually does this,
-        // it works off of the assumption that a grid exists
+    it('updateGrid updates a grid but keeps the same uids', function () {
+        let fid, originalUids;
+        return initGrid('test grid')
+            .then(assertResponseStatus(201))
+            .then(getResponseJson)
+            .then(json => {
+                originalUids = json.file.cols.map(col => col.uid);
+                fid = json.file.fid;
 
+                return updateGrid(
+                    [
+                        ['x', 10, 40, 70, 100, 130],
+                        ['y', 20, 50, 80, 110, 140],
+                        ['z', 30, 60, 90, 120, 150]
+                    ],
+                    genPlaceholderColumnNames(6),
+                    fid,
+                    username
+                );
+            })
+            .then(assertResponseStatus(200))
+            .then(() => {
+                return getGrid(fid, username);
+            })
+            .then(assertResponseStatus(200))
+            .then(getResponseJson)
+            .then(json => {
+                const finalUids = extractOrderedUids(json);
+                assert.equal(finalUids.length, 6);
+                assert.deepEqual(originalUids, finalUids, 'original and final uids differ');
+            })
+            .then(() => deleteGrid(fid, username));
+    });
+
+    it('updateGrid keeps all original uids when appending additional columns', function () {
+        let fid, originalUids;
+        return initGrid('test grid')
+            .then(assertResponseStatus(201))
+            .then(getResponseJson)
+            .then(json => {
+                originalUids = json.file.cols.map(col => col.uid);
+                fid = json.file.fid;
+
+                return updateGrid(
+                    [
+                        ['x', 10, 40, 70, 100, 130, 160, 190],
+                        ['y', 20, 50, 80, 110, 140, 170, 200],
+                        ['z', 30, 60, 90, 120, 150, 180, 210]
+                    ],
+                    genPlaceholderColumnNames(8),
+                    fid,
+                    username
+                );
+            })
+            .then(assertResponseStatus(201))
+            .then(() => {
+                return getGrid(fid, username);
+            })
+            .then(assertResponseStatus(200))
+            .then(getResponseJson)
+            .then(json => {
+                const finalUids = extractOrderedUids(json);
+                assert.equal(finalUids.length, 8);
+                assert.deepEqual(originalUids, finalUids.slice(0, 6), 'original and final uids differ');
+            })
+            .then(() => deleteGrid(fid, username));
+    });
+
+    it('updateGrid keeps subset of original uids when deleting columns', function () {
+        let fid, originalUids;
+        return initGrid('test grid')
+            .then(assertResponseStatus(201))
+            .then(getResponseJson)
+            .then(json => {
+                originalUids = json.file.cols.map(col => col.uid);
+                fid = json.file.fid;
+
+                return updateGrid(
+                    [
+                        ['x', 10, 40, 70],
+                        ['y', 20, 50, 80],
+                        ['z', 30, 60, 90]
+                    ],
+                    genPlaceholderColumnNames(4),
+                    fid,
+                    username
+                );
+            })
+            .then(assertResponseStatus(200))
+            .then(() => {
+                return getGrid(fid, username);
+            })
+            .then(assertResponseStatus(200))
+            .then(getResponseJson)
+            .then(json => {
+                const finalUids = extractOrderedUids(json);
+                assert.equal(finalUids.length, 4);
+                assert.deepEqual(originalUids.slice(0, 4), finalUids, 'original and final uids differ');
+            })
+            .then(() => deleteGrid(fid, username));
+    });
+
+    it('updateGrid overwrites a grid with correct data and column names', function () {
         let fid;
-        const newColumnNames = Array(6).fill('_').map((v, i) => String(i)); // placeholder column names
-        return initGrid('Test updateGrid')
+        const placeholderColumnNames = genPlaceholderColumnNames(6);
+        return initGrid('test grid')
         .then(assertResponseStatus(201))
         .then(getResponseJson).then(json => {
             fid = json.file.fid;
@@ -38,7 +143,7 @@ describe('Grid API Functions', function () {
                     ['y', 20, 50, 80, 110, 140],
                     ['z', 30, 60, 90, 120, 150]
                 ],
-                newColumnNames, // placeholder column names
+                placeholderColumnNames,
                 fid,
                 username
             );
@@ -50,27 +155,27 @@ describe('Grid API Functions', function () {
         .then(assertResponseStatus(200))
         .then(getResponseJson).then(json => {
             assert.deepEqual(
-                json.cols[newColumnNames[0]].data,
+                json.cols[placeholderColumnNames[0]].data,
                 ['x', 'y', 'z']
             );
             assert.deepEqual(
-                json.cols[newColumnNames[1]].data,
+                json.cols[placeholderColumnNames[1]].data,
                 [10, 20, 30]
             );
             assert.deepEqual(
-                json.cols[newColumnNames[2]].data,
+                json.cols[placeholderColumnNames[2]].data,
                 [40, 50, 60]
             );
             assert.deepEqual(
-                json.cols[newColumnNames[3]].data,
+                json.cols[placeholderColumnNames[3]].data,
                 [70, 80, 90]
             );
             assert.deepEqual(
-                json.cols[newColumnNames[4]].data,
+                json.cols[placeholderColumnNames[4]].data,
                 [100, 110, 120]
             );
             assert.deepEqual(
-                json.cols[newColumnNames[5]].data,
+                json.cols[placeholderColumnNames[5]].data,
                 [130, 140, 150]
             );
         })

--- a/test/backend/plotly-api.spec.js
+++ b/test/backend/plotly-api.spec.js
@@ -32,7 +32,6 @@ describe('Grid API Functions', function () {
         .then(assertResponseStatus(201))
         .then(getResponseJson).then(json => {
             fid = json.file.fid;
-            const uids = json.file.cols.map(col => col.uid);
             return updateGrid(
                 [
                     ['x', 10, 40, 70, 100, 130],
@@ -41,7 +40,6 @@ describe('Grid API Functions', function () {
                 ],
                 newColumnNames, // placeholder column names
                 fid,
-                uids,
                 username
             );
         })

--- a/test/backend/plotly-api.spec.js
+++ b/test/backend/plotly-api.spec.js
@@ -39,6 +39,7 @@ describe('Grid API Functions', function () {
                     ['y', 20, 50, 80, 110, 140],
                     ['z', 30, 60, 90, 120, 150]
                 ],
+                Array(3).fill('_'), // placeholder column names
                 fid,
                 uids,
                 username

--- a/test/backend/plotly-api.spec.js
+++ b/test/backend/plotly-api.spec.js
@@ -11,7 +11,6 @@ import {
     assertResponseStatus,
     getResponseJson,
     initGrid,
-    names,
     username
 } from './utils.js';
 
@@ -28,6 +27,7 @@ describe('Grid API Functions', function () {
         // it works off of the assumption that a grid exists
 
         let fid;
+        const newColumnNames = Array(6).fill('_').map((v, i) => String(i)); // placeholder column names
         return initGrid('Test updateGrid')
         .then(assertResponseStatus(201))
         .then(getResponseJson).then(json => {
@@ -39,7 +39,7 @@ describe('Grid API Functions', function () {
                     ['y', 20, 50, 80, 110, 140],
                     ['z', 30, 60, 90, 120, 150]
                 ],
-                Array(3).fill('_'), // placeholder column names
+                newColumnNames, // placeholder column names
                 fid,
                 uids,
                 username
@@ -52,27 +52,27 @@ describe('Grid API Functions', function () {
         .then(assertResponseStatus(200))
         .then(getResponseJson).then(json => {
             assert.deepEqual(
-                json.cols[names[0]].data,
+                json.cols[newColumnNames[0]].data,
                 ['x', 'y', 'z']
             );
             assert.deepEqual(
-                json.cols[names[1]].data,
+                json.cols[newColumnNames[1]].data,
                 [10, 20, 30]
             );
             assert.deepEqual(
-                json.cols[names[2]].data,
+                json.cols[newColumnNames[2]].data,
                 [40, 50, 60]
             );
             assert.deepEqual(
-                json.cols[names[3]].data,
+                json.cols[newColumnNames[3]].data,
                 [70, 80, 90]
             );
             assert.deepEqual(
-                json.cols[names[4]].data,
+                json.cols[newColumnNames[4]].data,
                 [100, 110, 120]
             );
             assert.deepEqual(
-                json.cols[names[5]].data,
+                json.cols[newColumnNames[5]].data,
                 [130, 140, 150]
             );
         })

--- a/test/backend/routes.queries.spec.js
+++ b/test/backend/routes.queries.spec.js
@@ -128,7 +128,9 @@ describe('Routes:', () => {
                 });
         });
 
-        it('can register queries if the user is a collaborator', function() {
+        // disabled because collaborators cannot register queries since
+        // they lack permission to update metadata
+        xit('can register queries if the user is a collaborator', function() {
             /*
              * Plotly doesn't have a v2 endpoint for creating
              * collaborators, so we'll just use these hardcoded

--- a/test/backend/routes.queries.spec.js
+++ b/test/backend/routes.queries.spec.js
@@ -159,7 +159,7 @@ describe('Routes:', () => {
             return POST('queries', queryObject)
                 .then(assertResponseStatus(201))
                 .then(getResponseJson).then((json) => {
-                    assert.deepEqual(json, {
+                    queryObject = {
                       ...queryObject,
                       uids: [
                         '08bd63',
@@ -169,11 +169,12 @@ describe('Routes:', () => {
                         '3c7496',
                         'b6b0bb'
                       ]
-                    });
-                    return GET('queries').then(getResponseJson)
-                      .then((getResponse) => {
-                        assert.deepEqual(getResponse, [json]);
-                      });
+                    };
+                    assert.deepEqual(json, queryObject);
+                    return GET('queries');
+                })
+                .then(getResponseJson).then((json) => {
+                    assert.deepEqual(json, [queryObject]);
                 });
         });
 

--- a/test/backend/routes.queries.spec.js
+++ b/test/backend/routes.queries.spec.js
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {merge} from 'ramda';
+import {merge, omit} from 'ramda';
 import uuid from 'uuid';
 
 import {saveConnection} from '../../backend/persistent/Connections.js';
@@ -17,8 +17,7 @@ import {
     POST,
     sqlConnections,
     username,
-    validFid,
-    validUids
+    validFid
 } from './utils.js';
 
 
@@ -34,7 +33,6 @@ describe('Routes:', () => {
         connectionId = saveConnection(sqlConnections);
         queryObject = {
             fid: validFid,
-            uids: validUids.slice(0, 2), // since this particular query only has 2 columns
             refreshInterval: 60, // every minute
             cronInterval: null,
             query: 'SELECT * FROM ebola_2014 LIMIT 1',
@@ -102,12 +100,10 @@ describe('Routes:', () => {
                 .then(assertResponseStatus(201))
                 .then(getResponseJson).then(json => {
                     fid = json.file.fid;
-                    const uids = json.file.cols.map(col => col.uid);
 
                     queryObject = {
                         fid,
                         requestor: fid.split(':')[0],
-                        uids,
                         refreshInterval: 60,
                         cronInterval: null,
                         connectionId,
@@ -118,12 +114,15 @@ describe('Routes:', () => {
                 })
                 .then(assertResponseStatus(201))
                 .then(getResponseJson).then(json => {
-                    assert.deepEqual(json, queryObject);
+                    assert.deepEqual(omit(json, 'uids'), omit(queryObject, 'uids'));
+                    assert.equal(json.uids.length, 6);
 
                     return GET('queries');
                 })
                 .then(getResponseJson).then(json => {
-                    assert.deepEqual(json, [queryObject]);
+                    assert.equal(json.length, 1);
+                    assert.deepEqual(omit(json[0], 'uids'), omit(queryObject, 'uids'));
+                    assert.equal(json[0].uids.length, 6);
 
                     return deleteGrid(fid, username);
                 });
@@ -144,12 +143,10 @@ describe('Routes:', () => {
                 apiKey: 'I6j80cqCVaBAnvH9ESD2'
             }]);
             const fid = 'plotly-database-connector:718';
-            const uids = ['d8ba6c', 'dfa411'];
 
             queryObject = {
                 fid,
                 requestor: collaborator,
-                uids,
                 refreshInterval: 60,
                 cronInterval: null,
                 connectionId,
@@ -186,12 +183,10 @@ describe('Routes:', () => {
                 apiKey: 'mUSjMmwa55d6hjvwvgI4'
             }]);
             const fid = 'plotly-database-connector:718';
-            const uids = ['d8ba6c', 'dfa411'];
 
             queryObject = {
                 fid,
                 requestor: viewer,
-                uids,
                 refreshInterval: 60,
                 cronInterval: null,
                 connectionId,
@@ -223,12 +218,10 @@ describe('Routes:', () => {
              * plot
              */
             const fid = 'plotly-database-connector:719';
-            const uids = ['3a6df9', 'b95e9d'];
 
             queryObject = {
                 fid,
                 requestor: viewer,
-                uids,
                 refreshInterval: 60,
                 cronInterval: null,
                 connectionId,

--- a/test/backend/routes.queries.spec.js
+++ b/test/backend/routes.queries.spec.js
@@ -237,34 +237,19 @@ describe('Routes:', () => {
         });
 
         it('gets individual queries', function() {
-          // uids are hardcoded
-          const uids = [
-            '9bbb87',
-            '8d4dd0',
-            '3e40ef',
-            'b169c0',
-            '55e326',
-            'e69f70'
-          ];
-          return GET(`queries/${queryObject.fid}`)
-              .then(assertResponseStatus(404)).then(() => {
-                  return POST('queries', queryObject);
-              })
-              .then(assertResponseStatus(201))
-              .then(getResponseJson).then(json => {
-                  assert.deepEqual(json, {
-                    ...queryObject,
-                    uids
-                  });
-                  return GET(`queries/${queryObject.fid}`);
-              })
-              .then(assertResponseStatus(200))
-              .then(getResponseJson).then(json => {
-                  assert.deepEqual(json, {
-                    ...queryObject,
-                    uids
-                  });
-              });
+            return GET(`queries/${queryObject.fid}`)
+                .then(assertResponseStatus(404)).then(() => {
+                    return POST('queries', queryObject);
+                })
+                .then(assertResponseStatus(201))
+                .then(getResponseJson).then(json => {
+                    assert.deepEqual(omit('uids', json), omit('uids', queryObject));
+                    return GET(`queries/${queryObject.fid}`);
+                })
+                .then(assertResponseStatus(200))
+                .then(getResponseJson).then(json => {
+                    assert.deepEqual(omit('uids', json), omit('uids', queryObject));
+                });
         });
 
         it('deletes queries', function() {

--- a/test/backend/routes.queries.spec.js
+++ b/test/backend/routes.queries.spec.js
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {merge, omit} from 'ramda';
+import {merge} from 'ramda';
 import uuid from 'uuid';
 
 import {saveConnection} from '../../backend/persistent/Connections.js';
@@ -159,8 +159,17 @@ describe('Routes:', () => {
             return POST('queries', queryObject)
                 .then(assertResponseStatus(201))
                 .then(getResponseJson).then((json) => {
-                    assert.deepEqual(omit('uids', json), omit('uids', queryObject));
-                    assert.equal(json.uids.length, 6);
+                    assert.deepEqual(json, {
+                      ...queryObject,
+                      uids: [
+                        '08bd63',
+                        '3430b2',
+                        '618517',
+                        '812006',
+                        '3c7496',
+                        'b6b0bb'
+                      ]
+                    });
                     return GET('queries').then(getResponseJson)
                       .then((getResponse) => {
                         assert.deepEqual(getResponse, [json]);
@@ -243,12 +252,32 @@ describe('Routes:', () => {
                 })
                 .then(assertResponseStatus(201))
                 .then(getResponseJson).then(json => {
-                    assert.deepEqual(omit('uids', json), omit('uids', queryObject));
+                    assert.deepEqual(json, {
+                      ...queryObject,
+                      uids: [
+                        '9bbb87',
+                        '8d4dd0',
+                        '3e40ef',
+                        'b169c0',
+                        '55e326',
+                        'e69f70'
+                      ]
+                    });
                     return GET(`queries/${queryObject.fid}`);
                 })
                 .then(assertResponseStatus(200))
                 .then(getResponseJson).then(json => {
-                    assert.deepEqual(omit('uids', json), omit('uids', queryObject));
+                    assert.deepEqual(json, {
+                      ...queryObject,
+                      uids: [
+                        '9bbb87',
+                        '8d4dd0',
+                        '3e40ef',
+                        'b169c0',
+                        '55e326',
+                        'e69f70'
+                      ]
+                    });
                 });
         });
 

--- a/test/backend/routes.queries.spec.js
+++ b/test/backend/routes.queries.spec.js
@@ -114,18 +114,18 @@ describe('Routes:', () => {
                         query: 'SELECT * from ebola_2014 LIMIT 2'
                     };
 
-                    return POST('queries', queryObject)
-                    .then(assertResponseStatus(201))
-                    .then(getResponseJson).then(json2 => {
-                        assert.deepEqual(json2, queryObject);
+                    return POST('queries', queryObject);
+                })
+                .then(assertResponseStatus(201))
+                .then(getResponseJson).then(json => {
+                    assert.deepEqual(json, queryObject);
 
-                        return GET('queries');
-                    })
-                    .then(getResponseJson).then(json3 => {
-                        assert.deepEqual(json3, [queryObject]);
+                    return GET('queries');
+                })
+                .then(getResponseJson).then(json => {
+                    assert.deepEqual(json, [queryObject]);
 
-                        return deleteGrid(fid, username);
-                    });
+                    return deleteGrid(fid, username);
                 });
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,6 +700,10 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
+aws4@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
+
 axios@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
@@ -2352,7 +2356,7 @@ colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
-combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
+combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5, combined-stream@~1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
@@ -4015,7 +4019,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.1:
+extend@^3.0.1, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
@@ -4243,8 +4247,8 @@ flush-write-stream@^1.0.0:
     readable-stream "^2.0.4"
 
 follow-redirects@^1.3.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.1.tgz#67a8f14f5a1f67f962c2c46469c79eaec0a90291"
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.3.tgz#ba150caf15e2f0b30c789993be9b912db553855b"
   dependencies:
     debug "^3.1.0"
 
@@ -4295,7 +4299,7 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@^2.3.1, form-data@~2.3.1:
+form-data@^2.3.1, form-data@~2.3.1, form-data@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   dependencies:
@@ -5043,15 +5047,15 @@ glslify@^6.0.2, glslify@^6.1.0, glslify@^6.1.1:
     xtend "^4.0.0"
 
 google-auth-library@^1.3.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-1.5.0.tgz#d9068f8bad9017224a4c41abcdcb6cf6a704e83b"
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-1.6.1.tgz#9c73d831ad720c0c3048ab89d0ffdec714d07dd2"
   dependencies:
     axios "^0.18.0"
     gcp-metadata "^0.6.3"
     gtoken "^2.3.0"
-    jws "^3.1.4"
+    jws "^3.1.5"
     lodash.isstring "^4.0.1"
-    lru-cache "^4.1.2"
+    lru-cache "^4.1.3"
     retry-axios "^0.3.2"
 
 google-auto-auth@^0.10.0:
@@ -5159,6 +5163,13 @@ har-validator@~5.0.3:
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
   dependencies:
     ajv "^5.1.0"
+    har-schema "^2.0.0"
+
+har-validator@~5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.0.tgz#44657f5688a22cfd4b72486e81b3a3fb11742c29"
+  dependencies:
+    ajv "^5.3.0"
     har-schema "^2.0.0"
 
 harmony-reflect@^1.4.6:
@@ -6441,7 +6452,7 @@ jwa@^1.1.5:
     ecdsa-sig-formatter "1.0.10"
     safe-buffer "^5.0.1"
 
-jws@^3.1.4:
+jws@^3.1.4, jws@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/jws/-/jws-3.1.5.tgz#80d12d05b293d1e841e7cb8b4e69e561adcf834f"
   dependencies:
@@ -6730,7 +6741,7 @@ lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
 
-lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@^4.1.2:
+lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   dependencies:
@@ -6972,11 +6983,21 @@ mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
+mime-db@~1.35.0:
+  version "1.35.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
+
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
     mime-db "~1.33.0"
+
+mime-types@~2.1.19:
+  version "2.1.19"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
+  dependencies:
+    mime-db "~1.35.0"
 
 mime@^1.2.11:
   version "1.6.0"
@@ -7576,6 +7597,10 @@ nwsapi@^2.0.0:
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
 
 object-assign@4.x, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
@@ -8667,7 +8692,7 @@ q@^1.1.2, q@^1.4.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
 
-qs@^6.2.1, qs@^6.5.1, qs@~6.5.1:
+qs@^6.2.1, qs@^6.5.1, qs@~6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
@@ -9616,7 +9641,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.45.0, request@^2.79.0, request@^2.81.0, request@^2.83.0:
+request@^2.45.0, request@^2.81.0, request@^2.83.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
@@ -9640,6 +9665,31 @@ request@^2.45.0, request@^2.79.0, request@^2.81.0, request@^2.83.0:
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
+
+request@^2.79.0:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -9769,8 +9819,8 @@ retry-axios@0.3.2, retry-axios@^0.3.2:
   resolved "https://registry.yarnpkg.com/retry-axios/-/retry-axios-0.3.2.tgz#5757c80f585b4cc4c4986aa2ffd47a60c6d35e13"
 
 retry-request@^3.0.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-3.3.1.tgz#fb71276235a617e97551e9be737ab5b91591fb9e"
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-3.3.2.tgz#fd8e0079e7b0dfc7056e500b6f089437db0da4df"
   dependencies:
     request "^2.81.0"
     through2 "^2.0.0"
@@ -9979,8 +10029,8 @@ schema-utils@^0.3.0:
     ajv "^5.0.0"
 
 schema-utils@^0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.5.tgz#21836f0608aac17b78f9e3e24daff14a5ca13a3e"
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
   dependencies:
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
@@ -10544,8 +10594,8 @@ stream-browserify@^2.0.1:
     readable-stream "^2.0.2"
 
 stream-each@^1.1.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.2.tgz#8e8c463f91da8991778765873fe4d960d8f616bd"
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz#ebe27a0c389b04fbcc233642952e10731afa9bae"
   dependencies:
     end-of-stream "^1.1.0"
     stream-shift "^1.0.0"
@@ -11119,7 +11169,7 @@ toposort-class@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toposort-class/-/toposort-class-1.0.1.tgz#7ffd1f78c8be28c3ba45cd4e1a3f5ee193bd9988"
 
-tough-cookie@>=2.3.3, tough-cookie@^2.3.1, tough-cookie@^2.3.3:
+tough-cookie@>=2.3.3, tough-cookie@^2.3.1, tough-cookie@^2.3.3, tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
   dependencies:
@@ -11441,7 +11491,7 @@ uuid@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
-uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
+uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 


### PR DESCRIPTION
Hi @shannonlal, this PR updates your branch `google-big-query`.

The main commit you want to check is https://github.com/shannonlal/falcon-sql-client/commit/fbd5fe8aa49d471099d73cd7fb802740de1907b6 . All the others are the result of bringing the branch in sync with Falcon v3.0.3.

In https://github.com/shannonlal/falcon-sql-client/commit/fbd5fe8aa49d471099d73cd7fb802740de1907b6 you'll find:
- I've introduced the use of `Pool` to avoid creating a new client for every request.
- I've also re-factored some of the code to answer your questions (or to get rid of unnecessary promises).

You'll find I've left 2 `TODO`s:
- in `connect`, we need to validate the connection (to do this, we want a request as cheap as possible; retrieving all the tables may be too slow for large numbers).
- in `schemas`, we have a similar problem: making a query per table may not scale well; specially if the all the queries are concurrent. I'd investigate the use SQL to do this.

---


**I haven't tested this PR; you may find mistakes!**
